### PR TITLE
fix for logging problem

### DIFF
--- a/src/director.py
+++ b/src/director.py
@@ -97,6 +97,10 @@ def main(configfile, test=False):
     
     # logging
     logger = logging.getLogger()
+    #set root-logger
+    if logger.getEffectiveLevel()>0:
+        logger.setLevel('NOTSET')
+
     formatter = logging.Formatter('%(asctime)s %(levelname)s %(message)s')
     if not test:
         try:


### PR DESCRIPTION
- Based on https://docs.python.org/2/library/logging.html - "Note that the root logger is created with level WARNING." only  thresholds equal or higher then WARNING will be logged to "log_file" even if log_level 
  in config file is set to DEBUG

Python 2.7.3 (default, Mar 13 2014, 11:03:55)

> > > import logging
> > > logger=logging.getLogger()
> > > logger.getEffectiveLevel()
> > > 30

python 2..6.9 have the same problem.

/pch
